### PR TITLE
Update ScanCode to version 30.1.0 and switch to Python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM python:2.7
+FROM python:3.10
 
-ENV SCANCODE_RELEASE=3.1.1
+ENV SCANCODE_RELEASE=30.1.0
 
 RUN apt-get update && apt-get install -y bzip2 xz-utils zlib1g libxml2-dev libxslt1-dev
 
-ADD "https://github.com/nexB/scancode-toolkit/releases/download/v${SCANCODE_RELEASE}/scancode-toolkit-${SCANCODE_RELEASE}.tar.bz2" .
+ADD "https://github.com/nexB/scancode-toolkit/archive/refs/tags/v${SCANCODE_RELEASE}.tar.gz" .
 
-RUN mkdir scancode-toolkit && tar xjvf scancode-toolkit-*.tar.bz2 -C scancode-toolkit --strip-components=1
+RUN mkdir scancode-toolkit && tar xzvf v${SCANCODE_RELEASE}.tar.gz -C scancode-toolkit --strip-components=1
 
 WORKDIR scancode-toolkit
 
@@ -14,4 +14,4 @@ RUN ./scancode --help
 
 ENV PATH=$HOME/scancode-toolkit:$PATH
 
-RUN pip2 install pyyaml
+RUN pip3 install pyyaml


### PR DESCRIPTION
This update to ScanCode version 30.1.0 to solve licenses problems detected at hal_atmel recently. In addition, it switch to use
Python3.10 instead legacy Python2.7.

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>