### PR TITLE
Dockerfile: reduce image size and update to latest scancode release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
-FROM python:3.10
+FROM python:3.12-slim
 
-ENV SCANCODE_RELEASE=30.1.0
+ENV SCANCODE_RELEASE=32.3.0
 
-RUN apt-get update && apt-get install -y bzip2 xz-utils zlib1g libxml2-dev libxslt1-dev
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    wget \
+    curl \
+    unzip \
+    bzip2 \
+    xz-utils \
+    zlib1g \
+    libxml2-dev \
+    libxslt1-dev \
+    libpopt0 \
+    && rm -rf /var/lib/apt/lists/*
 
-ADD "https://github.com/nexB/scancode-toolkit/archive/refs/tags/v${SCANCODE_RELEASE}.tar.gz" .
+RUN mkdir /opt/scancode-toolkit && \
+    wget -qO- "https://github.com/nexB/scancode-toolkit/archive/refs/tags/v${SCANCODE_RELEASE}.tar.gz" | \
+    tar xz --strip-components=1 -C /opt/scancode-toolkit
 
-RUN mkdir scancode-toolkit && tar xzvf v${SCANCODE_RELEASE}.tar.gz -C scancode-toolkit --strip-components=1
-
-WORKDIR scancode-toolkit
+WORKDIR /opt/scancode-toolkit
 
 RUN ./scancode --help
 
-ENV PATH=$HOME/scancode-toolkit:$PATH
+ENV PATH="/opt/scancode-toolkit:$PATH"
 
-RUN pip3 install pyyaml
+RUN pip3 install pyyaml --no-cache-dir


### PR DESCRIPTION
This bring the **image size down to 950 MB** (**from 1.47 GB** of ghcr.io/zephyrproject-rtos/scancode:v1.0.0), in addition to getting the latest scancode version since we were using a version from 3 years ago

- Updated base image to Python 3.12-slim
- Updated Scancode version to latest released version 32.3.0
- Do not get scancode archive using ADD as it bloats the image unecessarily
- Ensure apt-get is not too greedy and remove cache after install
- Install pip packages with --no-cache-dir option to save on image size